### PR TITLE
Compile Bootleggers using Linux WSL on Windows 10

### DIFF
--- a/core/combo/HOST_EXTRA_wsl-x86_64.mk
+++ b/core/combo/HOST_EXTRA_wsl-x86_64.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006 The Android Open Source Project
+# Copyright (C) 2018 The LineageOS Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,14 +14,5 @@
 # limitations under the License.
 #
 
-# Configuration for builds hosted on linux-x86_64.
-# Included by combo/select.mk
-
-define $(combo_var_prefix)transform-shared-lib-to-toc
-$(call _gen_toc_command_for_elf,$(1),$(2))
-endef
-
-# Microsoft Windows Subsystem for Linux
-ifeq ($(HOST_OS_IS_WSL),true)
-include $(BUILD_COMBOS)/HOST_EXTRA_wsl-x86_64.mk
-endif
+# Configuration for builds hosted on wsl-x86_64.
+# Included by combo/HOST_linux-x86_64.mk

--- a/core/dex_preopt_libart.mk
+++ b/core/dex_preopt_libart.mk
@@ -170,6 +170,9 @@ my_2nd_arch_prefix :=
 # In the case where LOCAL_ENFORCE_USES_LIBRARIES is true, PRIVATE_DEX2OAT_CLASS_LOADER_CONTEXT
 # contains the normalized path list of the libraries. This makes it easier to conditionally prepend
 # org.apache.http.legacy.boot based on the SDK level if required.
+ifeq ($(HOST_OS_IS_WSL),true)
+SINGLE_THREAD := "-j1"
+endif
 define dex2oat-one-file
 $(hide) rm -f $(2)
 $(hide) mkdir -p $(dir $(2))
@@ -184,6 +187,7 @@ source build/make/core/verify_uses_libraries.sh "$(1)" && \
 source build/make/core/construct_context.sh "$(PRIVATE_CONDITIONAL_USES_LIBRARIES_HOST)" "$(PRIVATE_CONDITIONAL_USES_LIBRARIES_TARGET)" && \
 ,) \
 ANDROID_LOG_TAGS="*:e" $(DEX2OAT) \
+	$(SINGLE_THREAD) \
 	--runtime-arg -Xms$(DEX2OAT_XMS) --runtime-arg -Xmx$(DEX2OAT_XMX) \
 	$${class_loader_context_arg} \
 	$${stored_class_loader_context_arg} \

--- a/core/envsetup.mk
+++ b/core/envsetup.mk
@@ -100,6 +100,12 @@ endif
 # HOST_OS
 ifneq (,$(findstring Linux,$(UNAME)))
   HOST_OS := linux
+    ifneq (,$(findstring Microsoft,$(shell uname -r)))
+      # Microsoft Windows Subsystem for Linux
+      # The HOST_OS is still Linux but with some limitations.
+      # Assumes that there are no other Microsoft Linux kernels
+      HOST_OS_IS_WSL := true
+    endif
 endif
 ifneq (,$(findstring Darwin,$(UNAME)))
   HOST_OS := darwin


### PR DESCRIPTION
Current Linux WSL doesn't support multithreading.
These commits will help encountering errors during last step (especially dex2oat)